### PR TITLE
Update cache.md

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -50,7 +50,7 @@ $app->cache = $cacheDriver;
 
 > 上面提到的 `app('redis')->connection($name)`, 这里的 `$name` 是 laravel 项目中配置文件 `database.php` 中 `redis` 配置名 `default`：https://github.com/laravel/laravel/blob/master/config/database.php#L118
 > 如果你使用的其它连接，对应传名称就好了。
-
+> 如果你在使用Laravel 5.4，应将`$predis = app('redis')->connection();`修改为：`$predis = app('redis')->connection()->client();`
 
 ## 使用自定义的缓存方式
 


### PR DESCRIPTION
Laravel 5.4中app('redis')->connection()返回的是Connection对象而不是Client对象。如下：

```php
>>> app('redis')->connection();
=> Illuminate\Redis\Connections\PredisConnection {#196}
>>> app('redis')->connection()->client();
=> Predis\Client {#197}
```