### PR TITLE
Update broadcast.md

### DIFF
--- a/broadcast.md
+++ b/broadcast.md
@@ -64,7 +64,7 @@ $broadcast->sendCard($cardId, $groupId);
 
 ### 群发消息给指定用户
 
-可以是一个用户，也可以是多个用户，但必须是数组。
+至少两个用户的openid，必须是数组。
 
 ```php
 $broadcast->send($messageType, $message, [$openId1, $openId2]);


### PR DESCRIPTION
经测试，群发消息给指定用户的时候，必须至少两个用户，否则报如下错误
`{ ["errcode"]=> int(40130) ["errmsg"]=> string(68) "invalid openid list size, at least two openid hint: [OGvDha0627ge25]" }`