### PR TITLE
fix weixin oauth url

### DIFF
--- a/oauth.md
+++ b/oauth.md
@@ -47,12 +47,12 @@ OAuth是一个关于授权（authorization）的开放网络标准，在全世�
 
 - **公众平台网页授权获取用户信息**
 
-  **授权 URL**: `https://api.weixin.qq.com/sns/authorize`
+  **授权 URL**: `https://open.weixin.qq.com/connect/oauth2/authorize`
   **Scopes**: `snsapi_base` 与 `snsapi_userinfo`
 
 - **开放平台网页登录**
 
-  **授权 URL**: `https://api.weixin.qq.com/sns/qrconnect`
+  **授权 URL**: `https://open.weixin.qq.com/connect/qrconnect`
   **Scopes**: `snsapi_login`
 
 他们的逻辑都一样：


### PR DESCRIPTION
文中的URL是错误的
https://api.weixin.qq.com/sns/authorize 应改为 https://open.weixin.qq.com/connect/oauth2/authorize
https://api.weixin.qq.com/sns/qrconnect 应改为 https://open.weixin.qq.com/connect/qrconnect