### PR TITLE
fix: add missing comma

### DIFF
--- a/menu.md
+++ b/menu.md
@@ -89,7 +89,7 @@ $buttons = [
         // 对应小程序的appid
         "appid" =>  "wxxxxxxxxxxxxxx",
         // 小程序路径
-        "pagepath" =>  "pages/call/phone"
+        "pagepath" =>  "pages/call/phone",
         // 备用网页url
         "url" =>  "http://xxx.xxx/xxx",
     ]


### PR DESCRIPTION
在添加小程序菜单的示例代码中：添加小程序路径的数组元素后面缺失了一个英文逗号
应该是超哥忘记了 ;)