### PR TITLE
Fix a bug about construct of Text scalar type hint

### DIFF
--- a/zh-CN/official-account/messages.md
+++ b/zh-CN/official-account/messages.md
@@ -273,7 +273,7 @@ $app->server->push(function ($message) {
 ```php
 use EasyWeChat\Kernel\Messages\Text;
 
-$message = new Text(['content' => 'Hello world!']);
+$message = new Text('Hello world!');
 
 $result = $app->customer_service->message($message)->to($openId)->send();
 //...


### PR DESCRIPTION
Argument 1 passed to EasyWeChat\Kernel\Messages\Text::__construct() must be of the type string.