### PR TITLE
[docs]【企业微信】[上传普通文件]中文文件名不显示问题修复

### DIFF
--- a/wework/media.md
+++ b/wework/media.md
@@ -28,13 +28,19 @@ $app->media->uploadVoice($path);
 ## 上传视频
 
 ```php
-$app->media->uploadVideo($path, $title, $description);
+$app->media->uploadVideo($path);
 ```
 
 ## 上传普通文件
 
 ```php
-$app->media->uploadFile($path);
+$path = '/path/to/企业微信操作手册.pdf'
+
+$form = [ //可选 发送时,中文文件名不显示或被过虑可传此参数
+    'filename' => '企业微信操作手册.pdf'
+];
+
+$app->media->uploadFile(string $path, array $form = []);
 ```
 
 ## 获取素材


### PR DESCRIPTION
企业微信】[上传普通文件]中文文件名不显示问题修复
另外上传视频并没有 $title, $description 参数,这是复制了公众号的
PR https://github.com/w7corp/easywechat/pull/2030